### PR TITLE
Attempt to fix `generate` in JAX 0.2.21.

### DIFF
--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -244,7 +244,7 @@ class CausalTransformer:
                                                                  ["batch", ...],
                                                                  ["batch", ...],
                                                                  ["batch", ...]),
-                                                        out_axes=["batch", ...],
+                                                        out_axes=(["shard", "batch", ...], ["batch", ...]),
                                                         axis_resources={'shard': 'mp', 'batch': 'dp'})
 
         self.move_xmap = jax.experimental.maps.xmap(fun=lambda x, _: to_bf16(x),


### PR DESCRIPTION
I followed the discussion here:
https://github.com/google/jax/issues/6962

Using simply `out_axes=["batch", "shard", ...],` also works, but then we
need to update the dimensions after generation: `decoded_tokens` would
be at `output[1][0][0]` instead of `output[1][0]`.